### PR TITLE
feat: allow custom element renderers

### DIFF
--- a/src/payloadLexicalReactRenderer.tsx
+++ b/src/payloadLexicalReactRenderer.tsx
@@ -170,6 +170,7 @@ export type ElementRenderers = {
     linebreak: () => React.ReactNode;
     tab: () => React.ReactNode;
     upload: (props: UploadNode) => React.ReactNode;
+    [key: string]: (props: any) => React.ReactNode;
 };
 
 export type RenderMark = (mark: Mark) => React.ReactNode;
@@ -394,6 +395,10 @@ export function PayloadLexicalReactRenderer<
 
             if (node.type === "upload") {
                 return elementRenderers.upload(node);
+            }
+
+            if (Object.keys(elementRenderers).includes(node.type)) {
+                return elementRenderers[node.type](node);
             }
 
             throw new Error(`Missing element renderer for node type '${node.type}'`);


### PR DESCRIPTION
I ported the lexical playground into my CMS and added a horizontal line. 

Turned out that this renderer is lacking a few lines to be able to render my custom elements.

Would be great if we could merge this or solve the issue in another way.

Thanks for the great renderer!!

Cheers!