### PR TITLE
fix: allow elements without children

### DIFF
--- a/src/payloadLexicalReactRenderer.tsx
+++ b/src/payloadLexicalReactRenderer.tsx
@@ -463,7 +463,7 @@ export function PayloadLexicalReactRenderer<
 
                 return (
                     <React.Fragment key={index}>
-                        {renderElement(node, serialize(node.children))}
+                        {renderElement(node, serialize(node.children || []))}
                     </React.Fragment>
                 );
             }),


### PR DESCRIPTION
In my case, when rendering a horizontalline, it has no children defined. The output/format is untouched form the lexical playground demo.

This small change allows the serializer to render elements without children!

Related: #17 